### PR TITLE
use official clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1879,6 +1881,7 @@ dependencies = [
  "thousands",
  "tokio",
  "tower",
+ "tracing",
  "url",
 ]
 
@@ -3514,6 +3517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5694,6 +5706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6085,6 +6106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6373,6 +6403,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.11.4",
  "proc-macro-error2",
  "proc-macro2",
@@ -678,7 +678,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck 0.5.0",
+ "heck",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -833,16 +833,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -872,12 +872,13 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1510,45 +1511,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_builder_cryo"
-version = "4.3.21-cryo"
+name = "clap"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e3a8989ce9e79041f7681f82e669c1a06724975fb8f5b7bd60e359e572da76"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex_cryo",
- "strsim 0.10.0",
+ "clap_lex",
+ "strsim",
 ]
 
 [[package]]
-name = "clap_cryo"
-version = "4.3.21-cryo"
+name = "clap_derive"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8216426fdf2f5ce7fa46197e3517adf8b1c0ab96d3dbf73469bc15f34ad6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
- "clap_builder_cryo",
- "clap_derive_cryo",
- "once_cell",
-]
-
-[[package]]
-name = "clap_derive_cryo"
-version = "4.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1cd2cebdb1ec98182edb745382a2b65d6bc254782de26316e4366d83d39988"
-dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
 ]
 
 [[package]]
-name = "clap_lex_cryo"
-version = "0.5.0"
+name = "clap_lex"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98979652585ac7c8d6267e363229b6a26bc4bf469c69e96442f85830ebc89f45"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clipboard-win"
@@ -1839,7 +1839,7 @@ version = "0.3.2"
 dependencies = [
  "alloy",
  "anstyle",
- "clap_cryo",
+ "clap",
  "color-print",
  "colored",
  "cryo_freeze",
@@ -1868,7 +1868,7 @@ dependencies = [
  "cryo_to_df",
  "futures",
  "governor",
- "heck 0.5.0",
+ "heck",
  "http-body-util",
  "indexmap 2.11.4",
  "indicatif",
@@ -1953,7 +1953,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.106",
 ]
 
@@ -2663,12 +2663,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -3104,15 +3098,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -3758,6 +3747,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -4804,7 +4799,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -5922,12 +5917,6 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -5947,7 +5936,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -6952,15 +6941,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6993,21 +6973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
  "windows-link 0.2.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7045,12 +7010,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7063,12 +7022,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7078,12 +7031,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7111,12 +7058,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7126,12 +7067,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7147,12 +7082,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7162,12 +7091,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ alloy-transport-http = { version = "1.0.9", default-features = false, features =
 anstyle = "1.0.4"
 async-trait = "0.1.74"
 chrono = { version = "0.4.31", features = ["serde"] }
-clap_cryo = { version = "4.3.21-cryo", features = [
+clap = { version = "4.3.21", features = [
     "derive",
     "color",
     "unstable-styles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ serde_json = "1.0.108"
 thiserror = "2.0"
 thousands = "0.2.0"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread", "sync"] }
+tracing = "0.1.41"
 
 [profile.dev]
 incremental = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,8 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = "0.3.20"
 
 [features]
 default = ["reqwest-default-tls"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 alloy = { workspace = true }
 anstyle = { workspace = true }
-clap_cryo = { workspace = true }
+clap = { workspace = true }
 color-print = { workspace = true }
 colored = { workspace = true }
 cryo_freeze = { workspace = true }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7,6 +7,9 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 
+#[macro_use]
+extern crate tracing;
+
 mod args;
 mod parse;
 mod remember;
@@ -15,6 +18,7 @@ mod run;
 // used in main.rs but not lib.rs
 use eyre as _;
 use tokio as _;
+use tracing_subscriber as _;
 
 pub use args::Args;
 pub use parse::{parse_args, parse_query, parse_str};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,6 @@
 //! cryo_cli is a cli for cryo_freeze
 
-use clap_cryo::Parser;
+use clap::Parser;
 
 pub use cryo_cli::{run, Args};
 use eyre::Result;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,20 +2,16 @@
 
 use clap_cryo::Parser;
 
-mod args;
-mod parse;
-mod remember;
-mod run;
-
-pub use args::Args;
+pub use cryo_cli::{run, Args};
 use eyre::Result;
 
 #[tokio::main]
 #[allow(unreachable_code)]
 #[allow(clippy::needless_return)]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
     let args = Args::parse();
-    match run::run(args).await {
+    match run(args).await {
         Ok(Some(freeze_summary)) if freeze_summary.errored.is_empty() => Ok(()),
         Ok(Some(_freeze_summary)) => std::process::exit(1),
         Ok(None) => Ok(()),
@@ -29,7 +25,7 @@ async fn main() -> Result<()> {
             // handle release build
             #[cfg(not(debug_assertions))]
             {
-                println!("{}", e);
+                tracing::error!("{}", e);
                 std::process::exit(1);
             }
         }

--- a/crates/cli/src/parse/args.rs
+++ b/crates/cli/src/parse/args.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cryo_freeze::{ExecutionEnv, FileOutput, ParseError, Query, Source};
 
 use crate::args::Args;
-use clap_cryo::Parser;
+use clap::Parser;
 
 use super::{execution, file_output, query, source};
 

--- a/crates/cli/src/parse/source.rs
+++ b/crates/cli/src/parse/source.rs
@@ -67,7 +67,7 @@ pub(crate) fn parse_rpc_url(args: &Args) -> Result<String, ParseError> {
         match endpoint {
             Ok(endpoint) => endpoint.map(|endpoint| endpoint.url),
             Err(e) => {
-                eprintln!("Could not load MESC data: {e}");
+                error!("Could not load MESC data: {e}");
                 None
             }
         }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -1,5 +1,5 @@
 use crate::{args, parse, remember};
-use clap_cryo::Parser;
+use clap::Parser;
 use color_print::cstr;
 use colored::Colorize;
 use cryo_freeze::{err, CollectError, ExecutionEnv, FreezeSummary};

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -43,7 +43,7 @@ fn load_or_remember_command(
     let remembered = remember::load_remembered_command(cryo_dir.to_path_buf())?;
     // Warn if the remembered command comes from a different Cryo version.
     if remembered.cryo_version != cryo_freeze::CRYO_VERSION {
-        eprintln!("remembered command comes from a different Cryo version, proceed with caution\n");
+        warn!("remembered command comes from a different Cryo version, proceed with caution\n");
     }
     print_remembered_command(&remembered.command);
     args = args.merge_with_precedence(remembered.args);

--- a/crates/freeze/Cargo.toml
+++ b/crates/freeze/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = { workspace = true }
 thousands = { workspace = true }
 tokio = { workspace = true }
 tower = "0.5.2"
+tracing = { workspace = true }
 url = "2.5.7"
 
 [features]

--- a/crates/freeze/src/lib.rs
+++ b/crates/freeze/src/lib.rs
@@ -7,6 +7,9 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 
+#[macro_use]
+extern crate tracing;
+
 mod collect;
 mod datasets;
 mod freeze;

--- a/crates/freeze/src/types/decoders/log_decoder.rs
+++ b/crates/freeze/src/types/decoders/log_decoder.rs
@@ -31,7 +31,7 @@ impl LogDecoder {
             Ok(event) => Ok(Self { event, raw: event_signature.clone() }),
             Err(e) => {
                 let err = format!("incorrectly formatted event {event_signature} (expect something like event Transfer(address indexed from, address indexed to, uint256 amount) err: {e}");
-                eprintln!("{err}");
+                error!("{err}");
                 Err(err)
             }
         }
@@ -119,7 +119,7 @@ impl LogDecoder {
                         map.entry(body_keys[idx].clone()).or_default().push(param);
                     }
                 }
-                Err(e) => eprintln!("error parsing log: {e:?}"),
+                Err(e) => error!("error parsing log: {e:?}"),
             }
         }
         map

--- a/crates/freeze/src/types/sources.rs
+++ b/crates/freeze/src/types/sources.rs
@@ -126,32 +126,9 @@ const DEFAULT_MAX_CONCURRENT_REQUESTS: u64 = 100;
 /// builder
 impl Source {
     /// initialize source
-    pub async fn init(rpc_url: Option<String>) -> Result<Source> {
-        let rpc_url: String = parse_rpc_url(rpc_url);
+    pub async fn new(rpc_url: String) -> Result<Source> {
         SourceBuilder::new().rpc_url(rpc_url).build().await
     }
-
-    // /// set rate limit
-    // pub fn rate_limit(mut self, _requests_per_second: u64) -> Source {
-    //     todo!();
-    // }
-}
-
-fn parse_rpc_url(rpc_url: Option<String>) -> String {
-    let mut url = match rpc_url {
-        Some(url) => url.clone(),
-        _ => match std::env::var("ETH_RPC_URL") {
-            Ok(url) => url,
-            Err(_e) => {
-                println!("must provide --rpc or set ETH_RPC_URL");
-                std::process::exit(0);
-            }
-        },
-    };
-    if !url.starts_with("http") {
-        url = "http://".to_string() + url.as_str();
-    };
-    url
 }
 
 /// Normalizes a raw RPC endpoint string by ensuring it has a URI scheme


### PR DESCRIPTION
The clap_cryo (along with clap_builder_cryo, clap_derive_cryo, clap_lex_cryo) based on v4.3.21 mainly introduce `is_number_range` to `is_new_arg` and `parse_short_arg`, but I found that in most cases, original/official clap works well with these format, see test `args::tests::test_short_blocks`. So we revert it to original clap to bump to the latest version.

I hope the behavior would be the same after this PR, tell me if you found some corner cases.

```patch
diff --git a/clap_builder/src/parser/parser.rs b/clap_builder/src/parser/parser.rs
index d6d8e8da..4b0ec21f 100644
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -632,7 +632,7 @@ impl<'cmd> Parser<'cmd> {
 
         if self.cmd[current_positional.get_id()].is_allow_hyphen_values_set()
             || (self.cmd[current_positional.get_id()].is_allow_negative_numbers_set()
-                && next.is_number())
+                && (next.is_number() || next.is_number_range()))
         {
             // If allow hyphen, this isn't a new arg.
             debug!("Parser::is_new_arg: Allow hyphen");
@@ -830,7 +830,7 @@ impl<'cmd> Parser<'cmd> {
 
         #[allow(clippy::blocks_in_if_conditions)]
         if matches!(parse_state, ParseState::Opt(opt) | ParseState::Pos(opt)
-                if self.cmd[opt].is_allow_hyphen_values_set() || (self.cmd[opt].is_allow_negative_numbers_set() && short_arg.is_number()))
+                if self.cmd[opt].is_allow_hyphen_values_set() || (self.cmd[opt].is_allow_negative_numbers_set() && (short_arg.is_number() || short_arg.is_number_range())))
         {
             debug!("Parser::parse_short_args: prior arg accepts hyphenated values",);
             return Ok(ParseResult::MaybeHyphenValue);
@@ -840,7 +840,7 @@ impl<'cmd> Parser<'cmd> {
             .get(&pos_counter)
             .map(|arg| arg.is_allow_negative_numbers_set())
             .unwrap_or_default()
-            && short_arg.is_number()
+            && (short_arg.is_number() || short_arg.is_number_range())
         {
             debug!("Parser::parse_short_arg: negative number");
             return Ok(ParseResult::MaybeHyphenValue);
diff --git a/clap_lex/src/lib.rs b/clap_lex/src/lib.rs
index d519a10c..c34bf2f8 100644
--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -119,6 +119,32 @@ pub use std::io::SeekFrom;
 
 pub use ext::OsStrExt;
 
+fn is_block_id(s: &str) -> bool {
+    s == "latest" || s.replace('_', "").parse::<i64>().is_ok() || is_order_of_magnitude(s)
+}
+
+fn is_order_of_magnitude(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+
+    let suffix = s.chars().last().unwrap();
+
+    match suffix {
+        'k' | 'K' | 'm' | 'M' | 'b' | 'B' => {}
+        _ => return false,
+    }
+
+    let without_suffix = &s[0..s.len() - 1];
+    let parts: Vec<&str> = without_suffix.split('.').collect();
+
+    match parts.len() {
+        1 => parts[0].parse::<i64>().is_ok(),
+        2 => parts[0].parse::<i64>().is_ok() && parts[1].parse::<i64>().is_ok(),
+        _ => false,
+    }
+}
+
 /// Command-line arguments
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct RawArgs {
@@ -307,6 +333,13 @@ impl<'s> ParsedArg<'s> {
             .unwrap_or_default()
     }
 
+    /// Does the number look like a block number range delimited by colons
+    pub fn is_number_range(&self) -> bool {
+        self.to_value()
+            .map(|s| s.split(':').all(|v| is_block_id(v) || v.is_empty()))
+            .unwrap_or_default()
+    }
+
     /// Treat as a long-flag
     pub fn to_long(&self) -> Option<(Result<&str, &OsStr>, Option<&OsStr>)> {
         let raw = self.inner;
@@ -412,6 +445,11 @@ impl<'s> ShortFlags<'s> {
         self.invalid_suffix.is_none() && self.utf8_prefix.as_str().parse::<f64>().is_ok()
     }
 
+    /// Does the number look like a number range delimited by colons
+    pub fn is_number_range(&self) -> bool {
+        self.utf8_prefix.as_str().split(':').all(|v| is_block_id(v) || v.is_empty())
+    }
+
     /// Advance the iterator, returning the next short flag on success
     ///
     /// On error, returns the invalid-UTF8 value
```